### PR TITLE
Cache function length correctly in stdlib_modern.js

### DIFF
--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -62,7 +62,7 @@ function caml_call_gen(f, args) {
         return caml_call_gen(f, nargs)
       };
     }}
-    g.l = d + 1;
+    g.l = d;
     return g;
   }
 }


### PR DESCRIPTION
This fixes a bug in `stdlib_modern.js` that slipped in via https://github.com/ocsigen/js_of_ocaml/commit/23f4f71a9bdf77e4b2adac1ddee7d23471e7cbb4. Perhaps this repository should run the tests under both `stdlib.js` and `stdlib_modern.js`, so that bugs like this get caught earlier.